### PR TITLE
Disable no-undef Rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,7 @@ module.exports = {
       },
     ],
     'default-param-last': ['warn'],
+    'no-undef': 0,
   },
 };
 


### PR DESCRIPTION
### Changes
Disable `eslint(no-undef)` rule.

### Details
ESLint does not use Typescript parser to determine whether a variable is defined or not; therefore, it is necessary to specify all global variables, constants & types inside eslintrc file.
Because Typescript compiler can find out when undeclared variable is used, `eslint(no-undef)` rule is pretty much redundant.

Also, `typescript-eslint` FAQ recommends to turn off the rule ([link](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors))
> We strongly recommend that you do not use the no-undef lint rule on TypeScript projects. The checks it provides are already provided by TypeScript without the need for configuration - TypeScript just does this significantly better.